### PR TITLE
Fix runtime CSV variable name

### DIFF
--- a/code/server_within_trial_predictions_PLSR_RF_SVM.R
+++ b/code/server_within_trial_predictions_PLSR_RF_SVM.R
@@ -102,4 +102,4 @@ print("--------------- Finished with SVM ----------------")
 algorithm <- c("PLSR", "RF", "SVM")
 times.df <- rbind(time_PLSR, time_RF, time_SVM) %>%
   cbind(algorithm) %>% as.data.frame() %>% dplyr::select(algorithm, everything())
-write.csv(time.df, "output/algorithm_runtimes.csv", rownames = F)
+write.csv(times.df, "output/algorithm_runtimes.csv", rownames = F)


### PR DESCRIPTION
## Summary
- fix variable name mismatch in runtime CSV

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a57d6a7608320975abe23ceaaa6a3